### PR TITLE
Removing transcript accession number.

### DIFF
--- a/cdot/hgvs/dataproviders/json_data_provider.py
+++ b/cdot/hgvs/dataproviders/json_data_provider.py
@@ -62,6 +62,7 @@ class AbstractJSONDataProvider(Interface):
             return "seqfetcher"
 
     def get_seq(self, ac, start_i=None, end_i=None):
+        ac = ac.split('.')[0]
         return self.seqfetcher.fetch_seq(ac, start_i, end_i)
 
     @staticmethod


### PR DESCRIPTION
When using cdot without a local SeqRepo database it throws an error when trying to retrieve the sequence from either ENSEMBL or RefSeq API because of the transcript version, and taking into account SeqRepo isn't actively updated since 2021, I'd discourage the use of the local database. Meaning with this simple implementation the error doesn't happen anymore and the variant mapping from `g_to_c` for example doesn't fail.