### PR TITLE
#100 Swap cdot.cc domain references to cdotlib.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import hgvs
 from hgvs.assemblymapper import AssemblyMapper
 from cdot.hgvs.dataproviders import JSONDataProvider, RESTDataProvider
 
-hdp = RESTDataProvider()  # Uses API server at cdot.cc
+hdp = RESTDataProvider()  # Uses API server at cdotlib.org
 # hdp = JSONDataProvider(["./cdot-0.2.14.refseq.grch37.json.gz"])  # Uses local JSON file
 
 am = AssemblyMapper(hdp,

--- a/cdot/hgvs/dataproviders/json_data_provider.py
+++ b/cdot/hgvs/dataproviders/json_data_provider.py
@@ -479,9 +479,9 @@ class RESTDataProvider(AbstractJSONDataProvider):
         super().__init__(assemblies=assemblies, mode=mode, cache=cache, seqfetcher=seqfetcher)
         if url is None:
             if secure:
-                url = "https://cdot.cc"
+                url = "https://cdotlib.org"
             else:
-                url = "http://cdot.cc"
+                url = "http://cdotlib.org"
         self.url = url
         self.transcripts = {}
         self.genes = {}

--- a/cdot/pyhgvs/pyhgvs_transcript.py
+++ b/cdot/pyhgvs/pyhgvs_transcript.py
@@ -114,9 +114,9 @@ class RESTPyHGVSTranscriptFactory(AbstractPyHGVSTranscriptFactory):
         super().__init__()
         if url is None:
             if secure:
-                url = "https://cdot.cc"
+                url = "https://cdotlib.org"
             else:
-                url = "http://cdot.cc"
+                url = "http://cdotlib.org"
         self.url = url
         self.transcripts = {}
 

--- a/docs/notes.txt
+++ b/docs/notes.txt
@@ -4,7 +4,7 @@ RefSeq and Ensembl transcripts are versioned (eg NM_153253.3 is version 3). Exon
 
 We provide a REST web API for retrieving RefSeq and Ensembl transcript version data https://github.com/SACGF/cdot_rest
 
-This is hosted here: http://cdot.cc/ - though we have obtained new url cdotlib.org - will move it there soon 
+This is hosted here: https://cdotlib.org/ (previously cdot.cc)
 
 And have written integration code for the two most popular Python HGVS libraries: BioCommons HGVS and Counsyl pyHGVS.
 

--- a/generate_transcript_data/Snakefile
+++ b/generate_transcript_data/Snakefile
@@ -274,7 +274,7 @@ rule process_gene_info_json:
             "{workflow.basedir}/cdot_gene_info.py" \
                 --gene-info {input} \
                 --output {output} \
-                --email cdot@cdot.cc
+                --email cdot@cdotlib.org
         """
 
 

--- a/paper/notes.md
+++ b/paper/notes.md
@@ -46,7 +46,7 @@ Rationale: cdot is a tool + data resource — the classic Application Note scope
 - [ ] Does VariantValidator support T2T? Confirm before claiming "first HGVS resource"
 - [ ] Does TARK support T2T? Same check
 - [ ] #36 (CanonicalTranscriptSelector) — must be implemented before submission; it's in the abstract
-- [ ] #100 — cdotlib.org migration from cdot.cc — URL in paper must be stable at submission
+- [ ] #100 — cdotlib.org migration from cdot.cc — code/docs references swapped; remaining: persist cdot_rest settings + cdot.cc→cdotlib.org redirect so URL in paper is stable at submission
 - [ ] Zenodo DOI for data files — register before submission
 - [ ] Corresponding author and co-author list
 - [ ] Cover letter: mention production use in VariantGrid/Shariant

--- a/tests/benchmark_hgvs.py
+++ b/tests/benchmark_hgvs.py
@@ -56,7 +56,7 @@ def main():
     if args.uta:
         hdp = hgvs.dataproviders.uta.connect()
     elif args.rest:
-        hdp = RESTDataProvider(seqfetcher=seqfetcher)  # Uses API server at cdot.cc
+        hdp = RESTDataProvider(seqfetcher=seqfetcher)  # Uses API server at cdotlib.org
     elif args.rest_insecure:
         hdp = RESTDataProvider(secure=False, seqfetcher=seqfetcher)
     elif args.json:


### PR DESCRIPTION
🤖 Written by Claude

Closes #100 (code/docs portion).

Swaps the `cdot.cc` → `cdotlib.org` references throughout the codebase so the REST clients default to the new domain:

- `RESTDataProvider` default host (biocommons client) — `https://cdotlib.org` / `http://cdotlib.org`
- `RESTPyHGVSTranscriptFactory` default host (PyHGVS client)
- `README.md`, `tests/benchmark_hgvs.py` comments
- `generate_transcript_data/Snakefile` Entrez `--email cdot@cdotlib.org`
- `docs/notes.txt` (now "hosted at cdotlib.org (previously cdot.cc)")
- `paper/notes.md` checklist item

Verified: `RESTDataProvider().url` → `https://cdotlib.org`; full test suite passes (104 passed, 5 skipped).

**Out of scope (infra, tracked on #100):** persisting the cdot_rest production settings, the `cdot.cc` → `cdotlib.org` redirect, and certbot instructions. Those need to land before the cited API URL is stable for the paper, so #100 should stay open after this merges.